### PR TITLE
Support Filer API-generated files

### DIFF
--- a/src/main/java/kompile/testing/Compilation.kt
+++ b/src/main/java/kompile/testing/Compilation.kt
@@ -4,12 +4,12 @@ import org.jetbrains.kotlin.cli.common.ExitCode
 import org.junit.ComparisonFailure
 import java.io.File
 
-class Compilation(private val error: String, private val exitCode: ExitCode, private val generatedKtDir: File) {
+class Compilation(private val error: String, private val exitCode: ExitCode, private val generatedDir: File) {
     fun succeeded(): SuccessfulCompilationClause {
         if (exitCode != ExitCode.OK) {
             throw ComparisonFailure(null, ExitCode.OK.name, exitCode.name)
         }
-        return SuccessfulCompilationClause(generatedKtDir)
+        return SuccessfulCompilationClause(generatedDir)
     }
 
     fun succeededWithoutWarnings(): SuccessfulCompilationClause {

--- a/src/main/java/kompile/testing/Compiler.kt
+++ b/src/main/java/kompile/testing/Compiler.kt
@@ -78,18 +78,17 @@ class Compiler(private val rootDir: File) {
                 args.add(it.toString())
             }
         }
-        val generatedDir = File(rootDir, "generated")
-        args.addAll(annotationProcessorArgs(generatedDir.path))
+        val sourceDir = File(rootDir, "kapt/sources")
+        args.addAll(annotationProcessorArgs(sourceDir))
         val systemErrBuffer = Buffer()
         val exitCode = K2JVMCompiler().exec(errStream = PrintStream(systemErrBuffer.outputStream()), args = *args.toTypedArray())
-        return Compilation(systemErrBuffer.readUtf8(), exitCode, generatedDir)
+        return Compilation(systemErrBuffer.readUtf8(), exitCode, sourceDir)
     }
 
-    private fun annotationProcessorArgs(generatedDirPath: String): List<String> {
-        val sourceDir = File(rootDir, "kapt/sources")
+    private fun annotationProcessorArgs(sourceDir: File): List<String> {
         val stubsDir = File(rootDir, "kapt/stubs")
         val kaptArgs = mutableMapOf<String, String>()
-        kaptArgs["kapt.kotlin.generated"] = generatedDirPath
+        kaptArgs["kapt.kotlin.generated"] = sourceDir.path
         val plugin = classpathFiles.find { it.name.startsWith("kotlin-annotation-processing-embeddable") }
         return listOf(
                 "-Xplugin=$plugin",


### PR DESCRIPTION
I simply changed `kapt.kotlin.generated` to the same directory where Filer API creates files so that both old way and Filer API are supported. We could keep them separate but I think eventually all APs should migrate to Filer API.